### PR TITLE
Configurable logging level #19

### DIFF
--- a/analytics/config.py
+++ b/analytics/config.py
@@ -26,7 +26,7 @@ def get_config_field(field: str, default_val = None, allowed_values = []):
     if len(allowed_values) > 0 and value not in allowed_values:
         raise Exception('{} value must be one of: {}, got: {}'.format(field, allowed_values, value))
 
-    if value == None:
+    if value is None:
         raise Exception('Please configure {}'.format(field))
 
     return value

--- a/analytics/config.py
+++ b/analytics/config.py
@@ -11,20 +11,30 @@ if config_exists:
     with open(CONFIG_FILE) as f:
         config = json.load(f)
 else:
-    print('Config file %s doesn`t exist, using defaults' % CONFIG_FILE)
+    print('Config file %s doesn`t exist, using environment variables / defaults' % CONFIG_FILE)
 
 
-def get_config_field(field: str, default_val = None):
+def get_config_field(field: str, default_val = None, allowed_values = []):
+    value = None
     if field in os.environ:
-        return os.environ[field]
+        value = os.environ[field]
+    elif config_exists and field in config and config[field] != '':
+        value = config[field]
+    elif default_val is not None:
+        value = default_val
 
-    if config_exists and field in config and config[field] != '':
-        return config[field]
+    if len(allowed_values) > 0 and value not in allowed_values:
+        raise Exception('{} value must be one of: {}, got: {}'.format(field, allowed_values, value))
 
-    if default_val is not None:
-        return default_val
+    if value == None:
+        raise Exception('Please configure {}'.format(field))
 
-    raise Exception('Please configure {}'.format(field))
+    return value
 
 HASTIC_SERVER_URL = get_config_field('HASTIC_SERVER_URL', 'ws://localhost:8002')
+LOGGING_LEVEL = get_config_field(
+    'HS_AL_LOGGING_LEVEL', 
+    'INFO', 
+    ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+)
 LEARNING_TIMEOUT = get_config_field('LEARNING_TIMEOUT', 120)

--- a/analytics/config.py
+++ b/analytics/config.py
@@ -35,6 +35,7 @@ HASTIC_SERVER_URL = get_config_field('HASTIC_SERVER_URL', 'ws://localhost:8002')
 LOGGING_LEVEL = get_config_field(
     'HS_AL_LOGGING_LEVEL', 
     'INFO', 
+    # TODO: make values case insensitive
     ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 )
 LEARNING_TIMEOUT = get_config_field('LEARNING_TIMEOUT', 120)

--- a/analytics/config.py
+++ b/analytics/config.py
@@ -33,7 +33,7 @@ def get_config_field(field: str, default_val = None, allowed_values = []):
 
 HASTIC_SERVER_URL = get_config_field('HASTIC_SERVER_URL', 'ws://localhost:8002')
 LOGGING_LEVEL = get_config_field(
-    'HS_AL_LOGGING_LEVEL', 
+    'HS_AN_LOGGING_LEVEL', 
     'INFO', 
     # TODO: make values case insensitive
     ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']

--- a/analytics/server.py
+++ b/analytics/server.py
@@ -86,10 +86,9 @@ async def app_loop():
 
 def run_server():
     loop = asyncio.get_event_loop()
-    #loop.set_debug(True)
+
     logger.info("Ok")
     init_services()
-    logger.info('Analytics process is running') # we need to print to stdout and flush
-    sys.stdout.flush()                    # because node.js expects it
+    logger.info('Analytics process is running')
 
     loop.run_until_complete(app_loop())

--- a/analytics/server.py
+++ b/analytics/server.py
@@ -18,6 +18,7 @@ server_service: services.ServerService = None
 data_service: services.DataService = None
 analytic_unit_manager: AnalyticUnitManager = None
 
+logging.root.setLevel(config.LOGGING_LEVEL)
 logger = logging.getLogger('SERVER')
 
 
@@ -88,7 +89,7 @@ def run_server():
     #loop.set_debug(True)
     logger.info("Ok")
     init_services()
-    print('Analytics process is running') # we need to print to stdout and flush
+    logger.info('Analytics process is running') # we need to print to stdout and flush
     sys.stdout.flush()                    # because node.js expects it
 
     loop.run_until_complete(app_loop())

--- a/analytics/services/server_service.py
+++ b/analytics/services/server_service.py
@@ -111,7 +111,7 @@ class ServerService(utils.concurrent.AsyncZmqActor):
                 self.__server_socket = None
                 # TODO: move to config
                 reconnect_delay = 3
-                print('connection is refused or lost, trying to reconnect in %s seconds' % reconnect_delay)
+                logger.info('connection is refused or lost, trying to reconnect in %s seconds' % reconnect_delay)
                 await asyncio.sleep(reconnect_delay)
         raise InterruptedError()
 


### PR DESCRIPTION
Closes #19 

Changes:
- new `HS_AL_LOGGING_LEVEL` config field to configure analytics logging level (default value: `INFO`)
- new `allowed_values` argument in `get_config_field` function
- change a few remaining `print` function calls to `logger.info`