### PR TITLE
Fix Docker run

### DIFF
--- a/analytics/config.py
+++ b/analytics/config.py
@@ -16,7 +16,7 @@ else:
 
 def get_config_field(field: str, default_val = None, allowed_values = []):
     value = None
-    if field in os.environ:
+    if field in os.environ and os.environ[field] != '':
         value = os.environ[field]
     elif config_exists and field in config and config[field] != '':
         value = config[field]


### PR DESCRIPTION
I got this error when tried to run Hastic in Docker:
`Exception: HS_AN_LOGGING_LEVEL value must be one of: ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], got:`

## Reason
We have `HS_AN_LOGGING_LEVEL: ${HS_AN_LOGGING_LEVEL}` line in `environment` of `docker-compose`, that's why `os.environ['HS_AN_LOGGING_LEVEL']` is empty string, not `None`

## Changes
- consider empty string as missing value