### PR TITLE
gitignore virtual env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ dist/
 __pycache__/
 test/
 .env
+
+# venv
+bin
+lib
+lib64
+share
+pyvenv.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ test/
 
 # venv
 bin
+!bin/server
 lib
 lib64
 share


### PR DESCRIPTION
I've created virueal env in the repo root: `python3 -m venv .`. It has created a few files / directories. This PR adds all files / directories created by `venv` to `.gitignore`